### PR TITLE
Update sed in-place argument to work across mac os and linux

### DIFF
--- a/personalize.sh
+++ b/personalize.sh
@@ -9,13 +9,22 @@ username=$1
 repository_name=$2
 image_name=$3
 
-find . -type f -name '*.yaml' -exec sed -E -i '' s#https://github.com/[-_a-zA-Z0-9]+#https://github.com/${username}#g {} +
-find . -type f -name '*.yaml' -exec sed -E -i '' s#ghcr.io/[-_a-zA-Z0-9]+#ghcr.io/${username}#g {} +
+# Set sed inline option based on OS
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # for macOS
+  SED_IN_PLACE_OPT="-i ''"
+else
+  # for Linux
+  SED_IN_PLACE_OPT="-i"
+fi
+
+find . -type f -name '*.yaml' -exec sed $SED_IN_PLACE_OPT -E "s#https://github.com/[-_a-zA-Z0-9]+#https://github.com/${username}#g" {} +
+find . -type f -name '*.yaml' -exec sed $SED_IN_PLACE_OPT -E "s#ghcr.io/[-_a-zA-Z0-9]+#ghcr.io/${username}#g" {} +
 
 if [ ! -z "$repository_name" ]; then
-  find . -type f -name '*.yaml' -exec sed -E -i '' "s#https://github.com/${username}/[-_a-zA-Z0-9]+#https://github.com/${username}/${repository_name}#g" {} +
+  find . -type f -name '*.yaml' -exec sed $SED_IN_PLACE_OPT -E "s#https://github.com/${username}/[-_a-zA-Z0-9]+#https://github.com/${username}/${repository_name}#g" {} +
 fi
 
 if [ ! -z "$image_name" ]; then
-  find . -type f -name '*.yaml' -exec sed -E -i '' "s#ghcr.io/${username}/[-_a-zA-Z0-9]+#ghcr.io/${username}/${image_name}#g" {} +
+  find . -type f -name '*.yaml' -exec sed $SED_IN_PLACE_OPT -E "s#ghcr.io/${username}/[-_a-zA-Z0-9]+#ghcr.io/${username}/${image_name}#g" {} +
 fi


### PR DESCRIPTION
## Overview

When running `./personalize.sh makigg` on WSL2 (Ubuntu 24.04), the following error was encountered:

```shell
❯ ./personalize.sh makigg
sed: can't read s#https://github.com/[-_a-zA-Z0-9]+#https://github.com/makigg#g: No such file or directory
sed: can't read s#ghcr.io/[-_a-zA-Z0-9]+#ghcr.io/makigg#g: No such file or directory
```

This error occurs because the syntax for replacing files using sed differs between Mac and Linux environments.
`-i ''` for Mac OS.
`-i` for Linux.

## Changes

- Modified the argument specification in the `sed` commands within `personalize.sh` to ensure proper operation on WSL2 (Ubuntu 24.04) and other Linux distributions.

## Testing

- Verified that executing `./personalize.sh makigg` on WSL2 (Ubuntu 24.04) now correctly performs the intended URL replacements.

Thank you for reviewing this pull request.
